### PR TITLE
fix: 리소스 로드의 순서 문제

### DIFF
--- a/src/main/java/kr/jclab/javautils/pluginloader/JarPluginClassLoader.java
+++ b/src/main/java/kr/jclab/javautils/pluginloader/JarPluginClassLoader.java
@@ -113,15 +113,15 @@ public class JarPluginClassLoader extends SecureClassLoader implements Closeable
         return null;
     }
 
-	@Override
-	public URL getResource(String name) {
-		Objects.requireNonNull(name);
-		URL url = findResource(name);
-		if (url == null) {
-			url = super.getResource(name);
-		}
-		return url;
-	}
+    @Override
+    public URL getResource(String name) {
+        Objects.requireNonNull(name);
+        URL url = findResource(name);
+        if (url == null) {
+            url = super.getResource(name);
+        }
+        return url;
+    }
 
 	public InputStream getResourceAsStream(String name) {
         URL url = getResource(name);
@@ -201,9 +201,9 @@ public class JarPluginClassLoader extends SecureClassLoader implements Closeable
                         try {
                             JarEntryWithFile jarEntry = JarPluginClassLoader.this.findJarEntryByPath(name);
                             if (jarEntry == null) return null;
-							String absName = name;
-							if (!absName.startsWith("/")) absName = "/" + absName;
-							return new URL(jarEntry.fileEntry.getBaseUrl() + absName);
+                            String absName = name;
+                            if (!absName.startsWith("/")) absName = "/" + absName;
+                            return new URL(jarEntry.fileEntry.getBaseUrl() + absName);
                         } catch (MalformedURLException e) {
                             throw new RuntimeException(e);
                         }

--- a/src/main/java/kr/jclab/javautils/pluginloader/JarPluginClassLoader.java
+++ b/src/main/java/kr/jclab/javautils/pluginloader/JarPluginClassLoader.java
@@ -113,7 +113,17 @@ public class JarPluginClassLoader extends SecureClassLoader implements Closeable
         return null;
     }
 
-    public InputStream getResourceAsStream(String name) {
+	@Override
+	public URL getResource(String name) {
+		Objects.requireNonNull(name);
+		URL url = findResource(name);
+		if (url == null) {
+			url = super.getResource(name);
+		}
+		return url;
+	}
+
+	public InputStream getResourceAsStream(String name) {
         URL url = getResource(name);
         try {
             if (url == null) {
@@ -191,7 +201,9 @@ public class JarPluginClassLoader extends SecureClassLoader implements Closeable
                         try {
                             JarEntryWithFile jarEntry = JarPluginClassLoader.this.findJarEntryByPath(name);
                             if (jarEntry == null) return null;
-                            return new URL(jarEntry.fileEntry.getBaseUrl() + name);
+							String absName = name;
+							if (!absName.startsWith("/")) absName = "/" + absName;
+							return new URL(jarEntry.fileEntry.getBaseUrl() + absName);
                         } catch (MalformedURLException e) {
                             throw new RuntimeException(e);
                         }


### PR DESCRIPTION
- getResource() Override
- 해당 URL의 리소스가 존재할 경우 이를 사용